### PR TITLE
修正未播放时选择下一首崩溃的bug

### DIFF
--- a/fm.py
+++ b/fm.py
@@ -292,10 +292,10 @@ class UI:
 
     def next_song(self):
         # 单曲循环
-        if self.loop_mode == 0:
+        if self.loop_mode == 0 and self.playing_btn is not None:
             self._on_item_pressed(self.playing_btn)
         # 全部循环
-        elif self.loop_mode == 1:
+        elif self.loop_mode == 1 and self.playing_btn is not None:
             index = self.playing_btn.index + 1
             if index >= len(self.btns):
                 index = 0

--- a/fm.py
+++ b/fm.py
@@ -215,6 +215,7 @@ class UI:
         self.loop_mode = 0
         self.next_song_alarm = None
         self.main = None
+        self.index = 0
 
         # 调色板
         self.palette = [
@@ -282,6 +283,7 @@ class UI:
     def stop_song(self):
         if self.playing_btn is not None:
             self.playing_btn.set_is_playing(False)
+            self.index = self.playing_btn.index
         self.playing_btn = None
 
         self.player.stop()
@@ -292,11 +294,19 @@ class UI:
 
     def next_song(self):
         # 单曲循环
-        if self.loop_mode == 0 and self.playing_btn is not None:
-            self._on_item_pressed(self.playing_btn)
+        if self.loop_mode == 0:
+            # 处于未播放状态时
+            if self.playing_btn is not None:
+                self._on_item_pressed(self.playing_btn)
+            else:
+                self._on_item_pressed(self.btns[self.index])
         # 全部循环
-        elif self.loop_mode == 1 and self.playing_btn is not None:
-            index = self.playing_btn.index + 1
+        elif self.loop_mode == 1:
+            # 处于未播放状态时
+            if self.playing_btn is None:
+                index = self.index
+            else:
+                index = self.playing_btn.index + 1
             if index >= len(self.btns):
                 index = 0
             next_song_btn = self.btns[index]


### PR DESCRIPTION
当处于单曲循环、全部播放模式的未播放状态时，通过左右键选择下一首程序会崩溃。

commit的解决方案是忽略这次操作。

或者也可以选择播放下一首的方案？